### PR TITLE
[FIX] Optimizing check_membership_expiry partners search

### DIFF
--- a/membership_variable_period/models/res_partner.py
+++ b/membership_variable_period/models/res_partner.py
@@ -11,7 +11,8 @@ class ResPartner(models.Model):
     def check_membership_expiry(self):
         """Force a recalculation on each partner that is member."""
         partners = self.search(
-            [('membership_state', 'not in', ['old', 'none'])])
+            [('membership_state', 'not in', ['old', 'none', 'free']),
+             ('associate_member', '=', False)])
         # It has to be triggered one by one to avoid an error
         for partner in partners:
             partner.write({'membership_state': 'none'})


### PR DESCRIPTION
Optimizing partners search which are going to be check for membership expiration.
- **Free**: A partner marked as free must not to be checked
- **Associate member = False**: Only partners with no associate member must be check, because his children (partner with him as associate member) will be update automatically.

Please @pedrobaeza, check if this is conceptually right and could be applied for any installation, thanks.
