### PR TITLE
[FIX] Exclude current line when searching for other membership_lines

### DIFF
--- a/membership_prorrate_variable_period/models/__init__.py
+++ b/membership_prorrate_variable_period/models/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import account_invoice
+from . import product_template

--- a/membership_prorrate_variable_period/models/account_invoice.py
+++ b/membership_prorrate_variable_period/models/account_invoice.py
@@ -21,24 +21,15 @@ class AccountInvoiceLine(models.Model):
         if product.membership_type == 'fixed':
             return super(AccountInvoiceLine, self)._get_membership_interval(
                 product, date)
-        if product.membership_interval_qty != 1:
-            raise exceptions.Warning(
-                _("It's not possible to prorrate periods which interval "
-                  "quantity is different from 1."))
         if product.membership_interval_unit == 'days':
             raise exceptions.Warning(
                 _("It's not possible to prorrate daily periods."))
         if product.membership_interval_unit == 'weeks':
             weekday = date.weekday()
             date_from = date - datetime.timedelta(weekday)
-            date_to = date_from + datetime.timedelta(6)
         elif product.membership_interval_unit == 'months':
             date_from = datetime.date(day=1, month=date.month, year=date.year)
-            last_month_day = calendar.monthrange(
-                date.year, date.month)[1]
-            date_to = datetime.date(
-                day=last_month_day, month=date.month, year=date.year)
         elif product.membership_interval_unit == 'years':
             date_from = datetime.date(day=1, month=1, year=date.year)
-            date_to = datetime.date(day=31, month=12, year=date.year)
+        date_to = product._get_next_date(date) - datetime.timedelta(1)
         return date_from, date_to

--- a/membership_prorrate_variable_period/models/account_invoice.py
+++ b/membership_prorrate_variable_period/models/account_invoice.py
@@ -4,7 +4,6 @@
 
 from openerp import models, exceptions, _
 import datetime
-import calendar
 
 
 class AccountInvoiceLine(models.Model):

--- a/membership_prorrate_variable_period/models/product_template.py
+++ b/membership_prorrate_variable_period/models/product_template.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, exceptions, api, _
+import datetime
+import calendar
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.multi
+    def _get_next_date(self, date):
+        res = super(ProductTemplate, self)._get_next_date(date)
+        if self.membership_interval_qty != 1:
+            raise exceptions.Warning(
+                _("It's not possible to prorrate periods which interval "
+                  "quantity is different from 1."))
+        if self.membership_interval_unit == 'days':
+            raise exceptions.Warning(
+                _("It's not possible to prorrate daily periods."))
+        if self.membership_interval_unit == 'weeks':
+            weekday = date.weekday()
+            date_from = date - datetime.timedelta(weekday)
+            res = date_from + datetime.timedelta(7)
+        elif self.membership_interval_unit == 'months':
+            last_month_day = calendar.monthrange(
+                date.year, date.month)[1]
+            res = (datetime.date(
+                day=last_month_day, month=date.month, year=date.year) +
+                datetime.timedelta(1))
+        elif self.membership_interval_unit == 'years':
+            res = (datetime.date(day=31, month=12, year=date.year) +
+                   datetime.timedelta(1))
+        return res

--- a/membership_prorrate_variable_period/models/product_template.py
+++ b/membership_prorrate_variable_period/models/product_template.py
@@ -3,9 +3,10 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import math
-from openerp import models, exceptions, api, _
 import datetime
 import calendar
+from dateutil.relativedelta import relativedelta
+from openerp import models, exceptions, api, _
 
 
 class ProductTemplate(models.Model):
@@ -17,7 +18,7 @@ class ProductTemplate(models.Model):
         if self.membership_interval_unit == 'days':
             raise exceptions.Warning(
                 _("It's not possible to prorrate daily periods."))
-        qty = int(math.ceil(qty))
+        qty = int(math.ceil(qty)) * self.membership_interval_qty
         if self.membership_interval_unit == 'weeks':
             weekday = date.weekday()
             date_from = date - datetime.timedelta(weekday)
@@ -25,7 +26,7 @@ class ProductTemplate(models.Model):
         elif self.membership_interval_unit == 'months':
             date_to = date
             if qty > 1:
-                date_to += datetime.timedelta(months=(qty - 1))
+                date_to += relativedelta(months=(qty - 1))
             last_month_day = calendar.monthrange(
                 date_to.year, date_to.month)[1]
             res = (datetime.date(
@@ -34,7 +35,7 @@ class ProductTemplate(models.Model):
         elif self.membership_interval_unit == 'years':
             date_to = date
             if qty > 1:
-                date_to += datetime.timedelta(years=(qty - 1))
+                date_to += relativedelta(years=(qty - 1))
             res = (datetime.date(day=31, month=12, year=date_to.year) +
                    datetime.timedelta(1))
         return res

--- a/membership_prorrate_variable_period/models/product_template.py
+++ b/membership_prorrate_variable_period/models/product_template.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import math
 from openerp import models, exceptions, api, _
 import datetime
 import calendar
@@ -10,26 +12,29 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     @api.multi
-    def _get_next_date(self, date):
+    def _get_next_date(self, date, qty=1):
         res = super(ProductTemplate, self)._get_next_date(date)
-        if self.membership_interval_qty != 1:
-            raise exceptions.Warning(
-                _("It's not possible to prorrate periods which interval "
-                  "quantity is different from 1."))
         if self.membership_interval_unit == 'days':
             raise exceptions.Warning(
                 _("It's not possible to prorrate daily periods."))
+        qty = int(math.ceil(qty))
         if self.membership_interval_unit == 'weeks':
             weekday = date.weekday()
             date_from = date - datetime.timedelta(weekday)
-            res = date_from + datetime.timedelta(7)
+            res = date_from + datetime.timedelta(7 * qty)
         elif self.membership_interval_unit == 'months':
+            date_to = date
+            if qty > 1:
+                date_to += datetime.timedelta(months=(qty - 1))
             last_month_day = calendar.monthrange(
-                date.year, date.month)[1]
+                date_to.year, date_to.month)[1]
             res = (datetime.date(
-                day=last_month_day, month=date.month, year=date.year) +
+                day=last_month_day, month=date_to.month, year=date_to.year) +
                 datetime.timedelta(1))
         elif self.membership_interval_unit == 'years':
-            res = (datetime.date(day=31, month=12, year=date.year) +
+            date_to = date
+            if qty > 1:
+                date_to += datetime.timedelta(years=(qty - 1))
+            res = (datetime.date(day=31, month=12, year=date_to.year) +
                    datetime.timedelta(1))
         return res

--- a/membership_prorrate_variable_period/tests/test_membership_prorrate_variable_period.py
+++ b/membership_prorrate_variable_period/tests/test_membership_prorrate_variable_period.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Antiun Ingeniería S.L. - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 import datetime
 from dateutil.relativedelta import relativedelta
 from openerp import exceptions, fields
@@ -104,10 +105,56 @@ class TestMembershipProrrateVariablePeriod(common.TransactionCase):
         self.assertEqual(self.partner.member_lines[0].date_from, '2016-07-01')
         self.assertEqual(self.partner.member_lines[0].date_to, '2016-12-31')
 
-    def test_create_invoice_exceptions(self):
+    def test_get_next_date(self):
+        # Weeks
+        self.product.membership_interval_qty = 1
+        self.product.membership_interval_unit = 'weeks'
+        date = fields.Date.from_string('2015-07-01')
+        self.assertEqual(
+            datetime.date(day=6, month=7, year=2015),
+            self.product._get_next_date(date))
+        self.assertEqual(
+            datetime.date(day=20, month=7, year=2015),
+            self.product._get_next_date(date, qty=3))
+        self.product.membership_interval_qty = 2
+        self.assertEqual(
+            datetime.date(day=10, month=8, year=2015),
+            self.product._get_next_date(date, qty=3))
+        # Months
+        date = fields.Date.from_string('2015-07-31')
+        self.product.membership_interval_qty = 1
+        self.product.membership_interval_unit = 'months'
+        self.assertEqual(
+            datetime.date(day=1, month=8, year=2015),
+            self.product._get_next_date(date))
+        self.assertEqual(
+            datetime.date(day=1, month=10, year=2015),
+            self.product._get_next_date(date, qty=3))
+        self.product.membership_interval_qty = 2
+        self.assertEqual(
+            datetime.date(day=1, month=3, year=2016),
+            self.product._get_next_date(date, qty=4))
+        # Years
+        date = fields.Date.from_string('2015-07-31')
+        self.product.membership_interval_qty = 1
+        self.product.membership_interval_unit = 'years'
+        self.assertEqual(
+            datetime.date(day=1, month=1, year=2016),
+            self.product._get_next_date(date))
+        self.assertEqual(
+            datetime.date(day=1, month=1, year=2018),
+            self.product._get_next_date(date, qty=3))
+        self.product.membership_interval_qty = 2
+        self.assertEqual(
+            datetime.date(day=1, month=1, year=2021),
+            self.product._get_next_date(date, qty=3))
+
+    def test_exceptions(self):
         # Test daily period
         self.product.membership_interval_qty = 1
         self.product.membership_interval_unit = 'days'
+        with self.assertRaises(exceptions.Warning):
+            self.product._get_next_date(fields.Date.from_string('2015-07-01'))
         with self.assertRaises(exceptions.Warning):
             self.env['account.invoice'].create(
                 {'partner_id': self.partner.id,

--- a/membership_prorrate_variable_period/tests/test_membership_prorrate_variable_period.py
+++ b/membership_prorrate_variable_period/tests/test_membership_prorrate_variable_period.py
@@ -105,14 +105,6 @@ class TestMembershipProrrateVariablePeriod(common.TransactionCase):
         self.assertEqual(self.partner.member_lines[0].date_to, '2016-12-31')
 
     def test_create_invoice_exceptions(self):
-        # Test period quantity different from 1
-        self.product.membership_interval_qty = 3
-        with self.assertRaises(exceptions.Warning):
-            self.env['account.invoice'].create(
-                {'partner_id': self.partner.id,
-                 'account_id': self.partner.property_account_receivable.id,
-                 'invoice_line': [(0, 0, {'product_id': self.product.id,
-                                          'name': 'Membership error'})]})
         # Test daily period
         self.product.membership_interval_qty = 1
         self.product.membership_interval_unit = 'days'

--- a/membership_variable_period/models/__init__.py
+++ b/membership_variable_period/models/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Antiun Ingeniería S.L. - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 from . import product_template
+from . import product_product
 from . import account_invoice
 from . import res_partner

--- a/membership_variable_period/models/account_invoice.py
+++ b/membership_variable_period/models/account_invoice.py
@@ -17,6 +17,7 @@ class AccountInvoiceLine(models.Model):
         memb_line_model = self.env['membership.membership_line']
         memb_lines = memb_line_model.search(
             [('partner', '=', invoice.partner_id.id),
+             ('account_invoice_line', '!=', line_id),
              ('state', 'not in', ['none', 'canceled'])],
             order="date_to desc")
         if memb_lines and memb_lines[0].date_to:

--- a/membership_variable_period/models/account_invoice.py
+++ b/membership_variable_period/models/account_invoice.py
@@ -27,7 +27,7 @@ class AccountInvoiceLine(models.Model):
             'partner': invoice.partner_id.id,
             'membership_id': product.id,
             'member_price': price_unit,
-            'date': fields.Date.today(),
+            'date': invoice.date_invoice or fields.Date.today(),
             'date_from': fields.Date.to_string(date_from),
             'date_to': fields.Date.to_string(date_to),
             'state': 'waiting',

--- a/membership_variable_period/models/product_product.py
+++ b/membership_variable_period/models/product_product.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.multi
+    def _get_next_date(self, date, qty=1):
+        self.ensure_one()
+        return self.product_tmpl_id._get_next_date(date, qty=qty)

--- a/membership_variable_period/models/product_template.py
+++ b/membership_variable_period/models/product_template.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Antiun Ingeniería S.L. - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import math
 from openerp import models, fields, api
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
@@ -10,7 +12,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     @api.multi
-    def _get_next_date(self, date):
+    def _get_next_date(self, date, qty=1):
         """Get the date that results on incrementing given date an interval of
         time in time unit.
         @param date: Original date.
@@ -20,16 +22,17 @@ class ProductTemplate(models.Model):
         @return: The date incremented in 'interval' units of 'unit'.
         """
         self.ensure_one()
+        delta = self.membership_interval_qty * int(math.ceil(qty))
         if isinstance(date, str):
             date = fields.Date.from_string(date)
         if self.membership_interval_unit == 'days':
-            return date + timedelta(days=self.membership_interval_qty)
+            return date + timedelta(days=delta)
         elif self.membership_interval_unit == 'weeks':
-            return date + timedelta(weeks=self.membership_interval_qty)
+            return date + timedelta(weeks=delta)
         elif self.membership_interval_unit == 'months':
-            return date + relativedelta(months=self.membership_interval_qty)
+            return date + relativedelta(months=delta)
         elif self.membership_interval_unit == 'years':
-            return date + relativedelta(years=self.membership_interval_qty)
+            return date + relativedelta(years=delta)
 
     membership_type = fields.Selection(
         selection=[('fixed', 'Fixed dates'),

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -146,20 +146,19 @@ class TestMembershipVariablePeriod(common.TransactionCase):
         self.assertEqual(self.partner.membership_stop, '2015-07-20')
 
     def test_check_membership_expiry(self):
-        self.env['membership.membership_line'].create(
-            {'partner': self.partner.id,
-             'membership_id': self.product.id,
-             'member_price': 1.0,
-             'date': '2014-01-01',
-             'date_from': '2014-01-01',
-             'date_to': '2014-12-31',
-             'state': 'paid',
-             'account_invoice_line': self.env['account.invoice.line'].search(
-                 [], limit=1).id})
+        self.env['membership.membership_line'].create({
+            'partner': self.partner.id,
+            'membership_id': self.product.id,
+            'member_price': 1.0,
+            'date': '2014-01-01',
+            'date_from': '2014-01-01',
+            'date_to': '2014-12-31',
+            'state': 'paid',
+        })
         # Force state to let the calculation return to the computed one
         self.partner.membership_stop = '2014-12-31'
         self.env['res.partner'].check_membership_expiry()
-        self.assertEqual(self.partner.membership_state, 'none')
+        self.assertEqual(self.partner.membership_state, 'old')
 
     def test_get_next_date(self):
         test_suite = [

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -92,12 +92,8 @@ class TestMembershipVariablePeriod(common.TransactionCase):
                                       'quantity': 3.0})]}
         )
         membership_lines = invoice.invoice_line[0].membership_lines
-        self.assertEqual(len(membership_lines), 3)
-        self.assertEqual(membership_lines[2].date_from, '2015-07-01')
-        self.assertEqual(membership_lines[2].date_to, '2016-06-30')
-        self.assertEqual(membership_lines[1].date_from, '2016-07-01')
-        self.assertEqual(membership_lines[1].date_to, '2017-06-30')
-        self.assertEqual(membership_lines[0].date_from, '2017-07-01')
+        self.assertEqual(len(membership_lines), 1)
+        self.assertEqual(membership_lines[0].date_from, '2015-07-01')
         self.assertEqual(membership_lines[0].date_to, '2018-06-30')
         self.assertEqual(self.partner.membership_start, '2015-07-01')
         self.assertEqual(self.partner.membership_stop, '2018-06-30')
@@ -114,10 +110,8 @@ class TestMembershipVariablePeriod(common.TransactionCase):
         # Add quantity
         invoice.invoice_line[0].quantity = 2.0
         membership_lines = invoice.invoice_line[0].membership_lines
-        self.assertEqual(len(membership_lines), 2)
-        self.assertEqual(membership_lines[1].date_from, '2015-07-01')
-        self.assertEqual(membership_lines[1].date_to, '2016-06-30')
-        self.assertEqual(membership_lines[0].date_from, '2016-07-01')
+        self.assertEqual(len(membership_lines), 1)
+        self.assertEqual(membership_lines[0].date_from, '2015-07-01')
         self.assertEqual(membership_lines[0].date_to, '2017-06-30')
         self.assertEqual(self.partner.membership_start, '2015-07-01')
         self.assertEqual(self.partner.membership_stop, '2017-06-30')

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -81,6 +81,27 @@ class TestMembershipVariablePeriod(common.TransactionCase):
         self.assertEqual(self.partner.membership_start, '2016-07-01')
         self.assertEqual(self.partner.membership_stop, '2017-06-30')
 
+    def test_create_invoice_membership_product_year_several(self):
+        self.product.membership_interval_unit = 'years'
+        invoice = self.env['account.invoice'].create(
+            {'partner_id': self.partner.id,
+             'date_invoice': '2015-07-01',
+             'account_id': self.partner.property_account_receivable.id,
+             'invoice_line': [(0, 0, {'product_id': self.product.id,
+                                      'name': 'Membership with prorrate',
+                                      'quantity': 3.0})]}
+        )
+        membership_lines = invoice.invoice_line[0].membership_lines
+        self.assertEqual(len(membership_lines), 3)
+        self.assertEqual(membership_lines[2].date_from, '2015-07-01')
+        self.assertEqual(membership_lines[2].date_to, '2016-06-30')
+        self.assertEqual(membership_lines[1].date_from, '2016-07-01')
+        self.assertEqual(membership_lines[1].date_to, '2017-06-30')
+        self.assertEqual(membership_lines[0].date_from, '2017-07-01')
+        self.assertEqual(membership_lines[0].date_to, '2018-06-30')
+        self.assertEqual(self.partner.membership_start, '2015-07-01')
+        self.assertEqual(self.partner.membership_stop, '2018-06-30')
+
     def test_modify_invoice_membership_product(self):
         self.product.membership_interval_unit = 'years'
         invoice = self.env['account.invoice'].create(

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -156,7 +156,9 @@ class TestMembershipVariablePeriod(common.TransactionCase):
             'state': 'paid',
         })
         # Force state to let the calculation return to the computed one
-        self.partner.membership_stop = '2014-12-31'
+        free_state = self.partner.free_member
+        self.partner.write({'free_member': not free_state})
+        self.partner.write({'free_member': free_state})
         self.env['res.partner'].check_membership_expiry()
         self.assertEqual(self.partner.membership_state, 'old')
 


### PR DESCRIPTION
This exclusion is important to ignore the currently created membership_line.

Error case:
- Create a contract starting at 01/01/2016 for a member partner, with a product like:
  - membership_type = 'variable'
  - membership_interval_qty = 1
  - membership_interval_unit = 'years'
  - membership_prorrate = True
- Create an invoice

Current behavior:
- Membership line created is not starting at 01/01/2016

Expected behavior:
- Membership line created should start at 01/01/2016
