### PR TITLE
[FIX] Use invoice date as join date if defined

### DIFF
--- a/membership_variable_period/models/account_invoice.py
+++ b/membership_variable_period/models/account_invoice.py
@@ -31,7 +31,7 @@ class AccountInvoiceLine(models.Model):
             'partner': invoice.partner_id.id,
             'membership_id': product.id,
             'member_price': price_unit,
-            'date': fields.Date.today(),
+            'date': invoice.date_invoice or fields.Date.today(),
             'date_from': fields.Date.to_string(date_from),
             'date_to': fields.Date.to_string(date_to),
             'state': 'waiting',


### PR DESCRIPTION
Join date (membership.membership_line.date) is forced to be today, but when creating an invoice from a contract, invoice date is setting at create time, so this improvement allows to set this date according to invoice.
