### PR TITLE
[FIX] Use the same analytic_account as normal membership invoice line

### DIFF
--- a/membership_initial_fee/models/account_invoice.py
+++ b/membership_initial_fee/models/account_invoice.py
@@ -14,6 +14,7 @@ class AccountInvoiceLine(models.Model):
             'product_id': product_fee.id,
             'quantity': 1.0,
             'invoice_id': invoice_line.invoice_id.id,
+            'account_analytic_id': invoice_line.account_analytic_id.id,
         }
         line_dict = self.product_id_change(
             product_fee.id, False, line_vals['quantity'], '',


### PR DESCRIPTION
When using contract (account.analytic.account) membership invoice line is created with analytic_account.

This improvement allows that inital_fee invoice line have the same analytic_account as membership invoice line by default.
