### PR TITLE
[FIX] membership_extension: Refunds cancel

### DIFF
--- a/membership_extension/README.rst
+++ b/membership_extension/README.rst
@@ -64,6 +64,7 @@ Contributors
 ------------
 
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
 
 Maintainer
 ----------

--- a/membership_extension/__openerp__.py
+++ b/membership_extension/__openerp__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Association",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/membership_extension/models/account_invoice.py
+++ b/membership_extension/models/account_invoice.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, api
@@ -18,23 +19,42 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_cancel(self):
-        self.mapped('invoice_line').mapped('membership_lines').write({
+        """Cancel membership for customer invoices and restore previous
+        membership state for customer refunds. Harmless on supplier ones.
+        We detect dynamically if the module account_refund_original is
+        installed for accurate source invoice.
+        """
+        # TODO: Module in v9 is `account_invoice_refund_link`
+        self.mapped('invoice_line.membership_lines').write({
             'state': 'canceled',
         })
-        for refund in self.filtered(lambda r: r.type == 'out_refund'):
-            origin = self.search([
-                ('type', '=', 'out_invoice'),
-                ('number', '=', refund.origin),
-            ])
-            lines = origin.mapped('invoice_line').mapped('membership_lines')
-            if origin and lines:
-                origin_state = 'paid' if origin.state == 'paid' else 'invoiced'
-                lines.filtered(lambda r: r.state == 'canceled').write({
-                    'state': origin_state,
-                })
-                lines.write({
-                    'date_cancel': False,
-                })
+        refunds = self.filtered(lambda r: (
+            r.type == 'out_refund' and
+            # TODO: Rename this to `origin_invoice_ids` on v9
+            (r.origin or getattr(r, 'origin_invoices_ids', False))
+        ))
+        for refund in refunds:
+            # Search for the original invoice it modifies
+            if hasattr(refund, 'origin_invoices_ids'):
+                origins = refund.origin_invoices_ids
+            else:
+                # Try to match by origin string
+                origins = self.search([
+                    ('type', '=', 'out_invoice'),
+                    ('number', '=', refund.origin),
+                ])
+            for origin in origins:
+                lines = origin.mapped('invoice_line.membership_lines')
+                if origin and lines:
+                    origin_state = (
+                        'paid' if origin.state == 'paid' else 'invoiced'
+                    )
+                    lines.filtered(lambda r: r.state == 'canceled').write({
+                        'state': origin_state,
+                    })
+                    lines.write({
+                        'date_cancel': False,
+                    })
         return super(AccountInvoice, self).action_cancel()
 
     @api.multi


### PR DESCRIPTION
* Avoid ensure_one errors.
* Don't do anything when there's no origin (refund made from scratch or field erased).
* Use more accurate origin field (if refund link module installed)

cc @Tecnativa