### PR TITLE
[10.0][IMP] membership_delegated_partner: ensure delegated

### DIFF
--- a/membership_delegated_partner/__manifest__.py
+++ b/membership_delegated_partner/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Membership Delegate Partner',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Membership',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/membership_delegated_partner/models/membership_line.py
+++ b/membership_delegated_partner/models/membership_line.py
@@ -18,3 +18,13 @@ class MembershipLine(models.Model):
         if line.invoice_id.delegated_member_id:
             vals['partner'] = line.invoice_id.delegated_member_id.id
         return super(MembershipLine, self).create(vals)
+
+    def write(self, vals):
+        """If a partner is delegated, avoid reassign"""
+        if 'partner' not in vals:
+            return super(MembershipLine, self).write(vals)
+        if (self.account_invoice_line and
+                self.account_invoice_line.invoice_id.delegated_member_id):
+            vals['partner'] = (
+                self.account_invoice_line.invoice_id.delegated_member_id.id)
+        return super(MembershipLine, self).write(vals)

--- a/membership_delegated_partner/models/membership_line.py
+++ b/membership_delegated_partner/models/membership_line.py
@@ -23,8 +23,12 @@ class MembershipLine(models.Model):
         """If a partner is delegated, avoid reassign"""
         if 'partner' not in vals:
             return super(MembershipLine, self).write(vals)
-        if (self.account_invoice_line and
-                self.account_invoice_line.invoice_id.delegated_member_id):
-            vals['partner'] = (
-                self.account_invoice_line.invoice_id.delegated_member_id.id)
+        if vals.get('account_invoice_line'):
+            inv_line = self.env['account.invoice.line'].browse(
+                vals['account_invoice_line']
+            )
+        else:
+            inv_line = self.account_invoice_line
+        if inv_line and inv_line.invoice_id.delegated_member_id:
+            vals['partner'] = inv_line.invoice_id.delegated_member_id.id
         return super(MembershipLine, self).write(vals)

--- a/membership_delegated_partner/tests/test_membership_delegate.py
+++ b/membership_delegated_partner/tests/test_membership_delegate.py
@@ -33,7 +33,7 @@ class TestMembershipDelegate(common.SavepointCase):
 
     def test_01_delegate(self):
         """ Delegates membership to partner 2 """
-        self.env['account.invoice'].create({
+        invoice = self.env['account.invoice'].create({
             'name': "Test Customer Invoice",
             'journal_id': self.env['account.journal'].search(
                 [('type', '=', 'sale')])[0].id,
@@ -53,6 +53,13 @@ class TestMembershipDelegate(common.SavepointCase):
                          'Invoicing partner gets no line')
         # We try to force reassign member line to another partner
         self.partner2.member_lines.partner = ({'partner': self.partner1.id})
+        self.assertFalse(self.partner1.member_lines,
+                         "It's going to stand on partner2")
+        # Same test, with account_invoice_line in the write
+        self.partner2.member_lines.write({
+            'partner': self.partner1.id,
+            'account_invoice_line': invoice.invoice_line_ids[0].id,
+        })
         self.assertFalse(self.partner1.member_lines,
                          "It's going to stand on partner2")
 

--- a/membership_delegated_partner/tests/test_membership_delegate.py
+++ b/membership_delegated_partner/tests/test_membership_delegate.py
@@ -51,6 +51,10 @@ class TestMembershipDelegate(common.SavepointCase):
                         'Delegated partner gets the line')
         self.assertFalse(self.partner1.member_lines,
                          'Invoicing partner gets no line')
+        # We try to force reassign member line to another partner
+        self.partner2.member_lines.partner = ({'partner': self.partner1.id})
+        self.assertFalse(self.partner1.member_lines,
+                         "It's going to stand on partner2")
 
     def test_02_change_delegated_member(self):
         """ Delegated member can be changed later """


### PR DESCRIPTION
- In case some module tried to reset a partner's member line wich has a designated delegated member, that member should prevail.

cc @Tecnativa