### PR TITLE
[10.0][IMP] membership_extension: adhered member

### DIFF
--- a/membership_extension/README.rst
+++ b/membership_extension/README.rst
@@ -13,6 +13,9 @@ This module extends Odoo's membership management with the following features:
 * Do not calculate membership state from invoice status
 * Start date of last membership period
 * Partner's with member lines can't be deleted.
+* When a partner has an associated member there is the option to make member
+  start date independent from the associated member one so joining dates can be
+  tracked for those members.
 
 Configuration
 =============
@@ -39,6 +42,10 @@ not related with it.
 You will see a general membership status at partner level that specifies if
 it's a member of any category or not, and also a detail status per
 membership category.
+
+To make member start date independent from the associated member one, check the
+option *Adhered member* in the membership tab of the partner who is associating.
+A start date will now be available to edit.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -67,6 +74,7 @@ Contributors
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
+* Rafael Blasco <rafael.blasco@tecnativa.com>
 
 Maintainer
 ----------

--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -7,10 +7,11 @@
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "10.0.1.0.3",
-    "category": "Association",
-    "website": "https://odoo-community.org/",
-    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "version": "10.0.1.1.3",
+    "category": "Membership",
+    "author": "Tecnativa, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/oca/vertical-association",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/membership_extension/i18n/es.po
+++ b/membership_extension/i18n/es.po
@@ -113,7 +113,7 @@ msgstr "Fecha de inicio del último período"
 #. module: membership_extension
 #: model:ir.ui.menu,name:membership_extension.menu_marketing_config_association_item
 msgid "Membership Products"
-msgstr ""
+msgstr "Productos de socio"
 
 #. module: membership_extension
 #: model:ir.model.fields,field_description:membership_extension.field_res_partner_membership_categories
@@ -176,6 +176,24 @@ msgstr "Fecha de inicio del último período de asociación"
 #: model:ir.ui.view,arch_db:membership_extension.view_res_partner_member_filter
 msgid "Starting month of last membership period"
 msgstr "Mes de inicio del último período de asociación"
+
+#. module: membership_extension
+#: model:ir.model.fields,help:membership_extension.field_res_partner_is_adhered_member
+#: model:ir.model.fields,help:membership_extension.field_res_users_is_adhered_member
+msgid "A member who is associated to another one, but whose membership are independent."
+msgstr "Un socio asociado a otro pero cuya fecha de inicio es independiente."
+
+#. module: membership_extension
+#: model:ir.model.fields,field_description:membership_extension.field_res_partner_is_adhered_member
+#: model:ir.model.fields,field_description:membership_extension.field_res_users_is_adhered_member
+msgid "Adhered member"
+msgstr "Socio adherido"
+
+#. module: membership_extension
+#: model:ir.model.fields,help:membership_extension.field_res_partner_membership_start_adhered
+#: model:ir.model.fields,help:membership_extension.field_res_users_membership_start_adhered
+msgid "Date from which partner is adhered."
+msgstr "Fecha desde la cual está adherido."
 
 #. module: membership_extension
 #: model:ir.model,name:membership_extension.model_membership_membership_line

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -392,3 +392,20 @@ class TestMembership(common.SavepointCase):
         })
         partner2.unlink()
         self.assertFalse(partner2.exists())
+
+    def test_adhered_member(self):
+        self.env['membership.membership_line'].create({
+            'membership_id': self.gold_product.id,
+            'member_price': 100.00,
+            'date': fields.Date.today(),
+            'date_from': fields.Date.today(),
+            'date_to': self.next_month,
+            'partner': self.partner.id,
+            'state': 'waiting',
+        })
+        self.child.is_adhered_member = True
+        self.child.membership_start_adhered = '2018-01-26'
+        self.assertEqual(self.child.membership_start, '2018-01-26')
+        self.child.associate_member = False
+        self.child.onchange_associate_member()
+        self.assertFalse(self.child.is_adhered_member)

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -9,12 +9,20 @@
     <field name="inherit_id" ref="membership.view_partner_form" />
     <field name="priority" eval="999" />
     <field name="arch" type="xml">
+        <field name="membership_start" position="attributes">
+            <attribute name="attrs">
+                {'invisible':['|',('membership_start','=',False),('is_adhered_member', '=', True)]}
+            </attribute>
+        </field>
         <field name="membership_start" position="after">
+            <field name="membership_start_adhered"
+                   attrs="{'invisible':[('is_adhered_member','=',False)]}"/>
             <field name="membership_last_start"
                    attrs="{'invisible':[('membership_last_start','=',False)]}"/>
         </field>
         <field name="free_member" position="after">
             <field name="membership_category_ids" widget="many2many_tags"/>
+            <field name="is_adhered_member" attrs="{'invisible': [('associate_member', '=', False)]}"/>
         </field>
         <field name="member_lines" position="attributes">
             <attribute name="readonly">0</attribute>


### PR DESCRIPTION
- When a partner has an associated member there is the option to make member
  start date independent from the associated member one so joining dates can be
  tracked for those members.

- To make member start date independent from the associated member one, check the
  option *Adhered member* in the membership tab of the partner who is associating.
  A start date will now be available to edit.

cc @Tecnativa