### PR TITLE
[10.0][FIX] membership_extension: method-super mismatch

### DIFF
--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "category": "Association",
     "website": "https://odoo-community.org/",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/membership_extension/models/account_invoice.py
+++ b/membership_extension/models/account_invoice.py
@@ -22,10 +22,9 @@ class AccountInvoice(models.Model):
     def action_cancel(self):
         """Cancel membership for customer invoices and restore previous
         membership state for customer refunds. Harmless on supplier ones.
-        We detect dynamically if the module account_refund_original is
+        We detect dynamically if the module account_invoice_refund_link is
         installed for accurate source invoice.
         """
-        # TODO: Module in v9 is `account_invoice_refund_link`
         self.mapped('invoice_line_ids.membership_lines').write({
             'state': 'canceled',
         })

--- a/membership_extension/models/account_invoice.py
+++ b/membership_extension/models/account_invoice.py
@@ -19,7 +19,7 @@ class AccountInvoice(models.Model):
         return super(AccountInvoice, self).action_invoice_draft()
 
     @api.multi
-    def action_invoice_cancel(self):
+    def action_cancel(self):
         """Cancel membership for customer invoices and restore previous
         membership state for customer refunds. Harmless on supplier ones.
         We detect dynamically if the module account_refund_original is

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -341,7 +341,7 @@ class TestMembership(common.SavepointCase):
         self.assertEqual('canceled', line.state)
         refund.action_invoice_cancel()
         self.assertEqual('paid', line.state)
-        refund.action_invoice_cancel()
+        refund.action_cancel()
         refund.action_invoice_draft()
         refund.state = 'draft'  # HACK: Odoo resets this to open
         refund.invoice_line_ids[0].quantity = 0.5


### PR DESCRIPTION
There was a mismatch between a method and its super call that caused unexpected behaviour on other modules using the method.

cc @Tecnativa