### PR TITLE
[10.0][fix] membership_extension: add security group to menu

### DIFF
--- a/membership_extension/README.rst
+++ b/membership_extension/README.rst
@@ -16,6 +16,8 @@ This module extends Odoo's membership management with the following features:
 * When a partner has an associated member there is the option to make member
   start date independent from the associated member one so joining dates can be
   tracked for those members.
+* Adds a category for Membership management security group so a user with only
+  that permission can access to the membership menu.
 
 Configuration
 =============
@@ -75,6 +77,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Rafael Blasco <rafael.blasco@tecnativa.com>
+* Luis M. Ontalba <luis.martinez@tecnativa.com>
 
 Maintainer
 ----------

--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "10.0.1.1.4",
+    "version": "10.0.1.2.0",
     "category": "Membership",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -20,9 +20,10 @@
         "membership",
     ],
     "data": [
-        "security/ir.model.access.csv",
         "security/membership_security.xml",
+        "security/ir.model.access.csv",
         "views/membership_category_view.xml",
+        "views/membership_views.xml",
         "views/product_template_view.xml",
         "views/res_partner_view.xml",
         "data/membership_category_data.xml",

--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -2,12 +2,13 @@
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "10.0.1.1.3",
+    "version": "10.0.1.1.4",
     "category": "Membership",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
@@ -20,6 +21,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/membership_security.xml",
         "views/membership_category_view.xml",
         "views/product_template_view.xml",
         "views/res_partner_view.xml",

--- a/membership_extension/security/ir.model.access.csv
+++ b/membership_extension/security/ir.model.access.csv
@@ -3,3 +3,4 @@
 "access_membership_membership_category_membership_manager","membership_membership_category group_partner_manager","model_membership_membership_category","membership_extension.group_membership_manager",1,1,1,1
 "access_membership_membership_category","membership_membership_category group_user","model_membership_membership_category","base.group_user",1,0,0,0
 "access_membership_membership_line_membership_manager",membership.membership_line partner_manager,model_membership_membership_line,membership_extension.group_membership_manager,1,1,1,1
+"access_product_membership_manager",product.template.user,model_product_template,base.group_user,1,1,1,1

--- a/membership_extension/security/ir.model.access.csv
+++ b/membership_extension/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_membership_membership_category_partner_manager","membership_membership_category group_partner_manager","model_membership_membership_category","base.group_partner_manager",1,1,1,1
+"access_membership_membership_category_membership_manager","membership_membership_category group_partner_manager","model_membership_membership_category","membership_extension.group_membership_manager",1,1,1,1
 "access_membership_membership_category","membership_membership_category group_user","model_membership_membership_category","base.group_user",1,0,0,0
+"access_membership_membership_line_membership_manager",membership.membership_line partner_manager,model_membership_membership_line,membership_extension.group_membership_manager,1,1,1,1

--- a/membership_extension/security/membership_security.xml
+++ b/membership_extension/security/membership_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="membership.menu_association" model="ir.ui.menu">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+</odoo>

--- a/membership_extension/security/membership_security.xml
+++ b/membership_extension/security/membership_security.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="membership.menu_association" model="ir.ui.menu">
-        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
+    <record model="ir.module.category" id="module_category_membership_management">
+        <field name="name">Membership</field>
+        <field name="description">Helps you manage operations for managing memberships.</field>
+        <field name="sequence">3</field>
+    </record>
+
+    <record id="group_membership_manager" model="res.groups">
+        <field name="name">Membership manager</field>
+        <field name="category_id" ref="module_category_membership_management"/>
     </record>
 
 </odoo>

--- a/membership_extension/security/membership_security.xml
+++ b/membership_extension/security/membership_security.xml
@@ -8,7 +8,7 @@
     </record>
 
     <record id="group_membership_manager" model="res.groups">
-        <field name="name">Membership manager</field>
+        <field name="name">Manager</field>
         <field name="category_id" ref="module_category_membership_management"/>
     </record>
 

--- a/membership_extension/views/membership_views.xml
+++ b/membership_extension/views/membership_views.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="membership.menu_association" model="ir.ui.menu">
+        <field name="groups_id" eval="[(4, ref('membership_extension.group_membership_manager'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Add access right to the main menu "Members" to employees group, avoiding restriction for only accountants when the association module is installed.