### PR TITLE
[FIX] membership_initial_fee: getattr fails

### DIFF
--- a/membership_initial_fee/__manifest__.py
+++ b/membership_initial_fee/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Initial fee for memberships',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'license': 'AGPL-3',
     'category': 'Association',
     'author': 'Tecnativa, '

--- a/membership_initial_fee/models/account_invoice.py
+++ b/membership_initial_fee/models/account_invoice.py
@@ -39,7 +39,7 @@ class AccountInvoiceLine(models.Model):
         # if a special method is found, overwritten in other modules, then
         # the partner is got from that method
         partner = invoice_line.invoice_id.partner_id
-        if getattr(invoice_line,
+        if hasattr(invoice_line,
                    '_get_partner_for_membership'):  # pragma: no cover
             partner = invoice_line._get_partner_for_membership()
         # See if partner has any membership line


### PR DESCRIPTION
`getattr()` fails if the attribute doesn't exist. We use `hasattr()` instead.

cc @Tecnativa