### PR TITLE
[IMP] membership_extension: Adapt to standard refund field

### DIFF
--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
+# Copyright 2017-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "category": "Membership",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/membership_extension/models/account_invoice.py
+++ b/membership_extension/models/account_invoice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2017-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models
@@ -22,39 +22,24 @@ class AccountInvoice(models.Model):
     def action_cancel(self):
         """Cancel membership for customer invoices and restore previous
         membership state for customer refunds. Harmless on supplier ones.
-        We detect dynamically if the module account_invoice_refund_link is
-        installed for accurate source invoice.
         """
         self.mapped('invoice_line_ids.membership_lines').write({
             'state': 'canceled',
         })
         refunds = self.filtered(lambda r: (
-            r.type == 'out_refund' and
-            (r.origin or getattr(r, 'origin_invoice_ids', False))
+            r.type == 'out_refund' and r.refund_invoice_id
         ))
         for refund in refunds:
-            # Search for the original invoice it modifies
-            if hasattr(refund, 'origin_invoice_ids'):  # pragma: no cover
-                # If account_invoice_refund_link module is installed
-                origins = refund.origin_invoices_ids
-            else:
-                # Try to match by origin string
-                origins = self.search([
-                    ('type', '=', 'out_invoice'),
-                    ('number', '=', refund.origin),
-                ])
-            for origin in origins:
-                lines = origin.mapped('invoice_line_ids.membership_lines')
-                if origin and lines:
-                    origin_state = (
-                        'paid' if origin.state == 'paid' else 'invoiced'
-                    )
-                    lines.filtered(lambda r: r.state == 'canceled').write({
-                        'state': origin_state,
-                    })
-                    lines.write({
-                        'date_cancel': False,
-                    })
+            origin = refund.refund_invoice_id
+            lines = origin.mapped('invoice_line_ids.membership_lines')
+            if lines:
+                origin_state = 'paid' if origin.state == 'paid' else 'invoiced'
+                lines.filtered(lambda r: r.state == 'canceled').write({
+                    'state': origin_state,
+                })
+                lines.write({
+                    'date_cancel': False,
+                })
         return super(AccountInvoice, self).action_cancel()
 
     @api.multi


### PR DESCRIPTION
This module uses in previous versions an indirect dependency to account_invoice_refund_link for detecting the origin invoice where the refund comes from, but now there's a field in standard for
pointing to that origin invoice, so no need of such code.

@Tecnativa