### PR TITLE
[FIX] membership_variable_period: period calculation

### DIFF
--- a/membership_variable_period/__manifest__.py
+++ b/membership_variable_period/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Variable period for memberships',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'category': 'Association',
     'author': 'Tecnativa, '

--- a/membership_variable_period/models/account_invoice.py
+++ b/membership_variable_period/models/account_invoice.py
@@ -63,29 +63,8 @@ class AccountInvoiceLine(models.Model):
 
     @api.model
     def create(self, vals):
-        if not vals.get('product_id'):
-            return super(AccountInvoiceLine, self).create(vals)
-        product = self.env['product.product'].browse(vals['product_id'])
         price_unit = vals.get('price_unit', 0.0)
-        # HACK: When membership product is variable, dates are False and that
-        # causes that the member line dates are writen to '0000-00-00' which
-        # raises an error when written on the table. We write the date before
-        # and reset it after to prevent this.
-        flag_variable = False
-        if (product.membership and
-                not product.membership_date_to and
-                not product.membership_date_from and (
-                product.membership_type == 'variable')):
-            product.membership_type = (
-                'fixed' if 'variable' else product.membership_type)
-            product.membership_date_from = '0001-01-01'
-            product.membership_date_to = '0001-01-01'
-            flag_variable = True
         line = super(AccountInvoiceLine, self).create(vals)
-        if product.membership and flag_variable:
-            product.membership_date_to = False
-            product.membership_date_from = False
-            product.membership_type = 'variable'
         if (line.invoice_id.type == 'out_invoice' and
                 line.product_id.membership and
                 line.product_id.membership_type == 'variable'):


### PR DESCRIPTION
This hack can be removed since this was merged: https://github.com/odoo/odoo/commit/5d561ec934bb7a7c79885537675ce394d1841ec7#diff-812ad19ed9abdf121c61a62793bbebd4

It had some wrong interactions with other modules like `membership_prorate_variable_period`(https://github.com/OCA/vertical-association/pull/59)

cc @Tecnativa