### PR TITLE
[11.0][FIX] membership_extension: create new member_line after member_line cancel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -135,7 +135,8 @@ class ResPartner(models.Model):
                             date_from = line.date_from
                         if not last_to or last_to < line_date_to:
                             last_to = line_date_to
-                    if not last_cancel or last_cancel < line.date_cancel:
+                    if not last_cancel or (line.date_cancel
+                                           and last_cancel < line.date_cancel):
                         last_cancel = line.date_cancel
                 partner.membership_start = date_from
                 partner.membership_last_start = last_from


### PR DESCRIPTION
Fixes https://github.com/OCA/vertical-association/issues/73