### PR TITLE
[12.0][FIX] membership_initial_fee: Don't apply initial fee on refund/vendor

### DIFF
--- a/membership_initial_fee/__manifest__.py
+++ b/membership_initial_fee/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Tecnativa - Pedro M. Baeza
+# Copyright 2015-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 

--- a/membership_initial_fee/models/account_invoice.py
+++ b/membership_initial_fee/models/account_invoice.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Tecnativa - Pedro M. Baeza
+# Copyright 2015-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -43,17 +43,17 @@ class AccountInvoiceLine(models.Model):
         """
         # TODO: remove product parameter in v12
         product = product or self.product_id
-        if not product or not product.membership or (
-                product.initial_fee == 'none'):
+        if (not product or not product.membership or
+                product.initial_fee == 'none' or
+                self.invoice_id.type != "out_invoice"):
             return False
         # See if partner has any membership line to decide whether or not
         # to create the initial fee
-        member_lines = self.env['membership.membership_line'].search([
+        return not self.env['membership.membership_line'].search_count([
             ('partner', '=', self.invoice_id.partner_id.id),
             ('account_invoice_line', 'not in', (self.id,)),
             ('state', 'not in', ['none', 'canceled']),
         ])
-        return not bool(member_lines)
 
     @api.model
     def create(self, vals):

--- a/membership_initial_fee/tests/test_membership_initial_fee.py
+++ b/membership_initial_fee/tests/test_membership_initial_fee.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.tests import common
+from odoo.tests import common, Form
 
 
 class TestMembershipInitialFee(common.SavepointCase):
@@ -106,3 +106,17 @@ class TestMembershipInitialFee(common.SavepointCase):
         membership_product.product_fee = self.product
         membership_product.onchange_product_fee()
         self.assertEqual(membership_product.fixed_fee, self.product.list_price)
+
+    def test_refund_invoice(self):
+        invoice_form = Form(self.env["account.invoice"].with_context(
+            default_type="out_refund"
+        ))
+        invoice_form.partner_id = self.partner
+        with invoice_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_fixed
+            line_form.quantity = 1
+            line_form.price_unit = 10
+        invoice = invoice_form.save()
+        self.assertEqual(
+            len(invoice.invoice_line_ids), 1,
+            "The created invoice should have 1 line")


### PR DESCRIPTION
If you don't have any membership line, and you create a vendor bill/refund or a customer refund, the initial fee will be added to them, which is not correct.

The check for adding the initial fee now takes into account the invoice type for excluding those that are the non desired ones.

@Tecnativa TT25327