### PR TITLE
[14.0] [IMP] membership_extension: show/hide fields on membership lines

### DIFF
--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -40,20 +40,20 @@
                 expr="//field[@name='member_lines']/tree//field[@name='date']"
                 position="after"
             >
-                <field name="date_from" />
-                <field name="date_to" />
+                <field name="date_from" optional="show" />
+                <field name="date_to" optional="show" />
             </xpath>
             <xpath
                 expr="//field[@name='member_lines']/tree//field[@name='membership_id']"
                 position="after"
             >
-                <field name="category_id" />
+                <field name="category_id" optional="hide" />
             </xpath>
             <xpath
                 expr="//field[@name='member_lines']/tree//field[@name='date_to']"
                 position="after"
             >
-                <field name="date_cancel" />
+                <field name="date_cancel" optional="hide" />
             </xpath>
             <xpath expr="//field[@name='member_lines']/form" position="replace">
                 <form string="Memberships">


### PR DESCRIPTION
membership_extension adds many features to membership base module. (see [README](https://github.com/OCA/vertical-association/blob/14.0/membership_extension/README.rst))

It also adds several fields to the membership list view on the member form.

- date_from (From)
- date_to (To)
- date_cancel (Cancel date)
- category_id (Membership category)

This PR allows to show/hide these fields on the view (defaults for new members: show date_from/date_to, hide date_cancel/category_id).


![immagine](https://user-images.githubusercontent.com/227940/151003399-db5b8f4b-6b56-4d11-9c0e-189867dcd87c.png)

![immagine](https://user-images.githubusercontent.com/227940/151003237-feb73f09-a3c4-4895-b1cb-e8ccda66a234.png)

