### PR TITLE
[16.0][IMP] membership_extension: Prevent end date before start date on membership_line

### DIFF
--- a/membership_extension/models/membership_line.py
+++ b/membership_extension/models/membership_line.py
@@ -27,6 +27,14 @@ class MembershipLine(models.Model):
         compute="_compute_member_price", readonly=False, store=True
     )
 
+    _sql_constraints = [
+        (
+            "start_date_greater",
+            "check(date_to >= date_from)",
+            "Error ! Ending Date cannot be set before Beginning Date.",
+        ),
+    ]
+
     @api.depends("membership_id")
     def _compute_member_price(self):
         for partner in self:


### PR DESCRIPTION
This restraint exists on res.product upstream, but not on membership.membership_line. Let's add it here as well.

Internal task: https://gestion.coopiteasy.be/web#id=9738&action=475&active_id=395&model=project.task&view_type=form&menu_id=536