### PR TITLE
[FIX] membership_extension partner categories labels warning

### DIFF
--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -76,6 +76,7 @@ class ResPartner(models.Model):
         recursive=True,
     )
     membership_categories = fields.Char(
+        string="Membership Categories Labels",
         readonly=True,
         store=True,
         index=True,


### PR DESCRIPTION
on the res.partner,  membership_categories and membership_category_ids have the same label. this can be confusing and creates a warning everywhere in the logs.

This PR changes the label of membership_categories to avoid that