### PR TITLE
[16.0][IMP] membership_extension: check expiry on membership lines

### DIFF
--- a/membership_extension/models/membership_line.py
+++ b/membership_extension/models/membership_line.py
@@ -78,3 +78,15 @@ class MembershipLine(models.Model):
                 )
             )
         return super().unlink()  # pragma: no cover
+
+    def _check_member_line_expiry(self):
+        today = fields.Date.today()
+        lines = self.search(
+            [
+                ("state", "in", ["paid"]),
+                ("date_to", "<", today),
+            ]
+        )
+        for line in lines:
+            if line.state == "paid" and line.date_to and line.date_to < today:
+                line.state = "old"

--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -257,6 +257,8 @@ class ResPartner(models.Model):
     @api.model
     def check_membership_expiry(self):
         """Force a recalculation on expired members"""
+        # Start by recalculating expired membership lines
+        self.env["membership.membership_line"]._check_member_line_expiry()
         today = fields.Date.today()
         member_states = self._membership_member_states()
         partners = self.search(

--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -226,7 +226,7 @@ class ResPartner(models.Model):
                     if prior.get(line.state, 0) > prior.get(state):
                         state = line.state
                 if state == "none" and partner.member_lines.filtered(
-                    lambda r: r.state in member_states
+                    lambda r: r.state not in ["none"]
                 ):
                     state = "old"
                 partner.membership_state = state

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -183,6 +183,20 @@ class TestMembership(common.TransactionCase):
         self.assertEqual(fields.Date.today(), self.child.membership_last_start)
         self.assertEqual(self.next_two_months, self.child.membership_stop)
         self.assertEqual(self.yesterday, self.child.membership_cancel)
+        other_line.unlink()
+        self.assertEqual("old", self.partner.membership_state)
+        self.env["membership.membership_line"].create(
+            {
+                "membership_id": self.silver_product.id,
+                "member_price": 100.00,
+                "date": fields.Date.today(),
+                "date_from": None,
+                "date_to": self.next_two_months,
+                "partner": self.partner.id,
+                "state": "paid",
+            }
+        )
+        self.assertEqual("paid", self.partner.membership_state)
         self.partner.free_member = True
         self.assertEqual("free", self.child.membership_state)
 

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -141,12 +141,12 @@ class TestMembership(common.TransactionCase):
         self.assertEqual(self.yesterday, self.child.membership_stop)
         self.assertEqual(self.yesterday, self.child.membership_cancel)
         line.write({"state": "canceled"})
-        self.assertEqual("none", self.partner.membership_state)
+        self.assertEqual("old", self.partner.membership_state)
         self.assertFalse(self.partner.membership_start)
         self.assertFalse(self.partner.membership_last_start)
         self.assertFalse(self.partner.membership_stop)
         self.assertEqual(self.yesterday, self.partner.membership_cancel)
-        self.assertEqual("none", self.child.membership_state)
+        self.assertEqual("old", self.child.membership_state)
         self.assertFalse(self.child.membership_start)
         self.assertFalse(self.child.membership_last_start)
         self.assertFalse(self.child.membership_stop)
@@ -388,7 +388,7 @@ class TestMembership(common.TransactionCase):
             }
         )
         self.env["res.partner"]._cron_update_membership()
-        self.assertEqual(self.partner.membership_state, "none")
+        self.assertEqual(self.partner.membership_state, "old")
 
     @mute_logger("odoo.sql_db")
     def test_unlink(self):


### PR DESCRIPTION
Before this PR, only membership state is changed when expiring.

This means a partner can have membership lines with status "paid" event if the date_to is in the past.


This PR fixes it, now membership lines are also updated when expiring