### PR TITLE
[16.0][FIX] membership_extension: replace categories field by category_ids

### DIFF
--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -75,13 +75,6 @@ class ResPartner(models.Model):
         compute="_compute_membership_state",
         recursive=True,
     )
-    membership_categories = fields.Char(
-        string="Membership Categories Labels",
-        readonly=True,
-        store=True,
-        index=True,
-        compute="_compute_membership_state",
-    )
     membership_state = fields.Selection(
         selection=STATE,
         store=True,
@@ -198,13 +191,9 @@ class ResPartner(models.Model):
                 partner.membership_category_ids = [
                     (6, False, partner.associate_member.membership_category_ids.ids)
                 ]
-                partner.membership_categories = (
-                    partner.associate_member.membership_categories
-                )
             elif partner.free_member:
                 partner.membership_state = "free"
                 partner.membership_category_ids = [(5, False, False)]
-                partner.membership_categories = False
             else:
                 state = "none"
                 category_ids = []
@@ -234,10 +223,8 @@ class ResPartner(models.Model):
                     category_ids = list(set(category_ids))
                     category_names = list(set(category_names))
                     partner.membership_category_ids = [(6, False, category_ids)]
-                    partner.membership_categories = ", ".join(category_names)
                 else:
                     partner.membership_category_ids = [(5, False, False)]
-                    partner.membership_categories = False
 
     @api.model
     def check_membership_expiry(self):

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -199,9 +199,7 @@ class TestMembership(common.TransactionCase):
             }
         )
         self.assertEqual(self.category_gold, self.partner.membership_category_ids)
-        self.assertEqual("Gold", self.partner.membership_categories)
         self.assertEqual(self.category_gold, self.child.membership_category_ids)
-        self.assertEqual("Gold", self.child.membership_categories)
         line_two = self.env["membership.membership_line"].create(
             {
                 "membership_id": self.silver_product.id,
@@ -217,24 +215,16 @@ class TestMembership(common.TransactionCase):
             self.category_gold + self.category_silver,
             self.partner.membership_category_ids,
         )
-        self.assertTrue("Silver" in self.partner.membership_categories)
-        self.assertTrue("Gold" in self.partner.membership_categories)
         self.assertEqual(
             self.category_gold + self.category_silver,
             self.child.membership_category_ids,
         )
-        self.assertTrue("Silver" in self.child.membership_categories)
-        self.assertTrue("Gold" in self.child.membership_categories)
         line_one.write({"state": "canceled"})
         self.assertEqual(self.category_silver, self.partner.membership_category_ids)
-        self.assertEqual("Silver", self.partner.membership_categories)
         self.assertEqual(self.category_silver, self.child.membership_category_ids)
-        self.assertEqual("Silver", self.child.membership_categories)
         line_two.write({"state": "waiting"})
         self.assertFalse(self.partner.membership_category_ids.ids)
-        self.assertFalse(self.partner.membership_categories)
         self.assertFalse(self.child.membership_category_ids.ids)
-        self.assertFalse(self.child.membership_categories)
 
     def test_remove_membership_line_with_invoice(self):
         invoice_form = common.Form(

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -111,9 +111,9 @@
                 />
                 <filter
                     string="Membership Category"
-                    name="membership_categories"
+                    name="membership_category_ids"
                     domain="[('membership_state', 'in', ['invoiced', 'paid'])]"
-                    context="{'group_by':'membership_categories'}"
+                    context="{'group_by':'membership_category_ids'}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
The membership categories Char field has some drawbacks, the main one being not supporting translations.

Apparently replacing the filter on `membership_categories` by a filter on `membership_category_ids` just works, looking at the git history this field was added in Odoo 8.0 and not updated since, I suspect that it exists to circumvent an odoo limitation that does no longer exists.

I've removed the field and I don't find any regression so I guess this would be easier to remove it and use membership_category_ids everywhere instead.