### PR TITLE
[16.0][IMP] membership_extension & _variable_period: Make sure necessary fields are always truthy

### DIFF
--- a/contract_membership_delegated_partner/tests/test_delegated_partner_contract.py
+++ b/contract_membership_delegated_partner/tests/test_delegated_partner_contract.py
@@ -9,7 +9,13 @@ class TestMembershipDelegateSetup(TestContractBase):
     def setUpClass(cls):
         super(TestMembershipDelegateSetup, cls).setUpClass()
         cls.partner2 = cls.env["res.partner"].create({"name": "Mrs. Odoo"})
-        cls.product_1.membership = True
+        cls.product_1.write(
+            {
+                "membership_date_from": "2023-01-01",
+                "membership_date_to": "2023-01-02",
+                "membership": True,
+            }
+        )
         cls.contract.delegated_member_id = cls.partner2
 
     def test_01_generate_and_delegate(self):

--- a/membership_extension/demo/product_template_demo.xml
+++ b/membership_extension/demo/product_template_demo.xml
@@ -10,6 +10,11 @@
         <field name="name">Membership Gold</field>
         <field name="membership" eval="True" />
         <field name="type">service</field>
+        <field name="membership_date_from" eval="DateTime.today()" />
+        <field
+            name="membership_date_to"
+            eval="DateTime.today() + relativedelta(years=1)"
+        />
     </record>
     <record id="membership_1_product_template" model="product.template">
         <field
@@ -19,6 +24,11 @@
         <field name="name">Membership Silver</field>
         <field name="membership" eval="True" />
         <field name="type">service</field>
+        <field name="membership_date_from" eval="DateTime.today()" />
+        <field
+            name="membership_date_to"
+            eval="DateTime.today() + relativedelta(years=1)"
+        />
     </record>
     <record id="membership_2_product_template" model="product.template">
         <field
@@ -28,5 +38,10 @@
         <field name="name">Membership Bronze</field>
         <field name="membership" eval="True" />
         <field name="type">service</field>
+        <field name="membership_date_from" eval="DateTime.today()" />
+        <field
+            name="membership_date_to"
+            eval="DateTime.today() + relativedelta(years=1)"
+        />
     </record>
 </odoo>

--- a/membership_extension/models/product_template.py
+++ b/membership_extension/models/product_template.py
@@ -4,7 +4,8 @@
 
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -32,3 +33,13 @@ class ProductTemplate(models.Model):
             if record.company_id and record.membership_category_id.company_id:
                 if record.membership_category_id.company_id != record.company_id:
                     record.membership_category_id = False
+
+    @api.constrains("membership_date_from", "membership_date_to", "membership")
+    def _check_membership_dates(self):
+        if self.filtered(
+            lambda record: record.membership
+            and (not record.membership_date_from or not record.membership_date_to)
+        ):
+            raise ValidationError(
+                _("A membership product must have a start date and an end date.")
+            )

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -457,3 +457,41 @@ class TestMembership(common.TransactionCase):
             self.assertTrue(template.membership_category_id)
             template.company_id = company_b
             self.assertFalse(template.membership_category_id)
+
+    def test_no_dates(self):
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(
+                {
+                    "name": "Test Membership",
+                    "membership": True,
+                    "type": "service",
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(
+                {
+                    "name": "Test Membership",
+                    "membership": True,
+                    "type": "service",
+                    "membership_date_from": "1970-01-01",
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(
+                {
+                    "name": "Test Membership",
+                    "membership": True,
+                    "type": "service",
+                    "membership_date_to": "1970-01-01",
+                }
+            )
+        # No error
+        self.env["product.template"].create(
+            {
+                "name": "Test Membership",
+                "membership": True,
+                "type": "service",
+                "membership_date_from": "1970-01-01",
+                "membership_date_to": "1970-01-02",
+            }
+        )

--- a/membership_variable_period/migrations/16.0.1.1.0/pre-migration.py
+++ b/membership_variable_period/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE product_template
+        SET membership_interval_qty = 1
+        WHERE membership_interval_qty IS null;
+        """
+    )
+    cr.execute(
+        """
+        UPDATE product_template
+        SET membership_interval_unit = 'years'
+        WHERE membership_interval_unit IS null;
+        """
+    )

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -16,8 +16,6 @@ class TestMembershipVariablePeriod(common.TransactionCase):
             {
                 "name": "Membership product with variable period",
                 "membership": True,
-                "membership_date_from": "2015-01-01",
-                "membership_date_to": "2015-12-31",
                 "membership_type": "variable",
                 "membership_interval_qty": 1,
                 "membership_interval_unit": "weeks",


### PR DESCRIPTION
This is an additional sanity check to make sure that fields that are expected to be available are actually available.

The situation here is a little tricky. Especially as pertains date_from and date_to; these fields are `required=True` nowhere. Not on the product, not on the membership invoice, and not on the membership line. However, they _are_ set as required in the product and membership line views. If these values are ever empty, it's a sure sign that something went wrong somewhere, because the user should not be able to reach such a state via the UI.

One sure way to reach that state was via the demo data, however, which had no start and end dates. This is now fixed.

The situation for the variable period fields is similar. These fields should never be empty when the membership type is variable, and it's not typically possible to empty these values via the UI. For convenience's sake, I simply set them to required an sich, with a default value.