### PR TITLE
[16.0] [FIX] membership_prorate: fix for calculating quantity for prorate products

### DIFF
--- a/membership_prorate/models/account_move_line.py
+++ b/membership_prorate/models/account_move_line.py
@@ -31,7 +31,7 @@ class AccountMoveLine(models.Model):
         if date_invoice > date_to:
             date_invoice = date_to
         theoretical_duration = date_to - date_from + timedelta(1)
-        real_duration = date_to - date_invoice
+        real_duration = date_to - date_invoice + timedelta(1)
         if theoretical_duration != real_duration:
             return {
                 "quantity": round(

--- a/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
+++ b/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
@@ -63,7 +63,7 @@ class TestMembershipProrateVariablePeriod(TransactionCase):
 
     def test_create_invoice_membership_product_prorate_week(self):
         invoice = self.create_invoice("2015-01-01")  # It's thursday
-        self.assertAlmostEqual(invoice.invoice_line_ids[0].quantity, 0.43, 2)
+        self.assertAlmostEqual(invoice.invoice_line_ids[0].quantity, 0.57, 2)
         self.assertTrue(self.partner.member_lines)
         self.assertEqual(self.partner.member_lines[0].state, "waiting")
         self.assertEqual(
@@ -77,7 +77,7 @@ class TestMembershipProrateVariablePeriod(TransactionCase):
     def test_create_invoice_membership_product_prorate_month(self):
         self.product.membership_interval_unit = "months"
         invoice = self.create_invoice("2015-04-15")
-        self.assertAlmostEqual(invoice.invoice_line_ids[0].quantity, 0.5, 2)
+        self.assertAlmostEqual(invoice.invoice_line_ids[0].quantity, 0.53, 2)
         self.assertTrue(self.partner.member_lines)
         self.assertEqual(self.partner.member_lines[0].state, "waiting")
         self.assertEqual(


### PR DESCRIPTION
This PR tends to solve quantity calculations for prorate products.Consider the following scenario:
Define a membership product with fixed dates, set start date as 1st Feb 2024 and end date as 29th Feb 2024, then create an invoice ,set 1st Feb 2024 as start date and select the product and save.Ideally the qty should be set as 1, but its sets it as 0.97 without changes added in this PR.
Also, changes in test scripts were needed for prorate variable period as for a week, if we consider from Thursday, it would be 4 days including Thursday(Thursday,Friday,Saturday and Sunday) i.e 4/7 = approximately 57% and similarly for the month - its 16 days including 15th April so 16/30 =approximately 53%