### PR TITLE
[16.0] [FIX] membership_prorate: Prevent error when using prorate with variable period without membership_prorate_variable_period module installed

### DIFF
--- a/membership_prorate/models/account_move_line.py
+++ b/membership_prorate/models/account_move_line.py
@@ -26,6 +26,11 @@ class AccountMoveLine(models.Model):
         product = invoice_line.product_id
         date_invoice = invoice_line.move_id.invoice_date or fields.Date.today()
         date_from, date_to = self._get_membership_interval(product, date_invoice)
+        if not date_from:
+            return {
+                "quantity": 1.0,
+                "date_from": date_invoice,
+            }
         if date_invoice < date_from:
             date_invoice = date_from
         if date_invoice > date_to:


### PR DESCRIPTION
This PR aims to solve an unwanted error coming up when using prorates

Steps to reproduce the error:
1. Install membership_prorate and membership_variable_period modules that leads to auto installation of membership_prorate_variable_period module. 
2. Uninstall the membership_prorate_variable_period module (Users might do it as they want to use prorates with variable periods)
3. Setup a product with Membership Type set as 'variable' and Prorate enabled
4. Create a invoice with this product, the system would throw an error as
```
membership_prorate/models/account_move_line.py", line 29, in _prepare_invoice_line_prorate_vals
    if date_invoice < date_from:
TypeError: '<' not supported between instances of 'datetime.date' and 'bool'
```