### PR TITLE
[15.0][FIX] membership_extension: post() is deprecated since v14: Replace with action_post()

### DIFF
--- a/membership_extension/models/account_move.py
+++ b/membership_extension/models/account_move.py
@@ -38,9 +38,9 @@ class AccountMove(models.Model):
                 lines.write({"date_cancel": False})
         return res
 
-    def post(self):
+    def action_post(self):
         """Handle validated refunds for cancelling membership lines"""
-        res = super().post()
+        res = super().action_post()
         self.filtered(lambda m: (m.move_type == "out_invoice")).mapped(
             "invoice_line_ids.membership_lines"
         ).write({"state": "invoiced"})


### PR DESCRIPTION
post() is deprecated since v14: https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L2681

So we rarely get the state updated on the membership line. Especially on creditnotes

This should probably be ported to 14.0 and future versions