### PR TITLE
[16.0][FIX] membership_extension: post() is deprecated since v14

### DIFF
--- a/membership_extension/models/account_move.py
+++ b/membership_extension/models/account_move.py
@@ -44,9 +44,9 @@ class AccountMove(models.Model):
                 lines.write({"date_cancel": False})
         return res
 
-    def post(self):
+    def action_post(self):
         """Handle validated refunds for cancelling membership lines"""
-        res = super().post()
+        res = super().action_post()
         self.filtered(lambda m: (m.move_type == "out_invoice")).mapped(
             "invoice_line_ids.membership_lines"
         ).write({"state": "invoiced"})


### PR DESCRIPTION
Forward port of #180

Replaced by action_post(): https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L2681 So we rarely get the state updated on the membership line. Especially on creditnotes