### PR TITLE
[FIX] membership_extension: support restarted memberships

### DIFF
--- a/membership_delegated_partner/models/membership_line.py
+++ b/membership_delegated_partner/models/membership_line.py
@@ -30,7 +30,7 @@ class MembershipLine(models.Model):
             line = self.env["account.move.line"].browse(vals["account_invoice_line"])
             if line.move_id.delegated_member_id:
                 vals["partner"] = line.move_id.delegated_member_id.id
-        return super().create(vals)
+        return super().create(vals_list)
 
     def write(self, vals):
         """If a partner is delegated, avoid reassign"""

--- a/membership_extension/README.rst
+++ b/membership_extension/README.rst
@@ -119,6 +119,17 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-rafaelbn| image:: https://github.com/rafaelbn.png?size=40px
+    :target: https://github.com/rafaelbn
+    :alt: rafaelbn
+.. |maintainer-yajo| image:: https://github.com/yajo.png?size=40px
+    :target: https://github.com/yajo
+    :alt: yajo
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-rafaelbn| |maintainer-yajo| 
+
 This module is part of the `OCA/vertical-association <https://github.com/OCA/vertical-association/tree/16.0/membership_extension>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/membership_extension/__manifest__.py
+++ b/membership_extension/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Membership extension",
     "summary": "Improves user experience of membership addon",
-    "version": "16.0.2.1.2",
+    "version": "16.0.3.0.0",
     "category": "Membership",
     "author": "Tecnativa, Onestein, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/vertical-association",
@@ -15,6 +15,7 @@
     "application": False,
     "installable": True,
     "depends": ["membership"],
+    "maintainers": ["rafaelbn", "yajo"],
     "data": [
         "security/membership_security.xml",
         "security/ir.model.access.csv",

--- a/membership_extension/migrations/16.0.3.0.0/post-recompute.py
+++ b/membership_extension/migrations/16.0.3.0.0/post-recompute.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["res.partner"].search(
+        ["|", ("membership_cancel", "!=", False), ("membership_state", "=", "free")]
+    )._compute_membership_date()

--- a/membership_extension/models/membership_line.py
+++ b/membership_extension/models/membership_line.py
@@ -19,9 +19,7 @@ class MembershipLine(models.Model):
     )
     date_from = fields.Date(readonly=False)
     date_to = fields.Date(readonly=False)
-    state = fields.Selection(
-        compute="_compute_state", inverse="_inverse_state", store=True, readonly=False
-    )
+    state = fields.Selection(compute="_compute_state", readonly=False)
     partner = fields.Many2one(ondelete="restrict")
     member_price = fields.Float(
         compute="_compute_member_price", readonly=False, store=True
@@ -65,10 +63,6 @@ class MembershipLine(models.Model):
         return super(
             MembershipLine, self - no_invoice_lines - cancelled_lines
         )._compute_state()
-
-    # Empty method _inverse_state
-    def _inverse_state(self):
-        return True  # pragma: no cover
 
     def unlink(self):
         allow = self.env.context.get("allow_membership_line_unlink", False)

--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -97,7 +97,7 @@ class ResPartner(models.Model):
 
         List of membership line states that define a partner as member
         """
-        return ("invoiced", "paid")
+        return ("invoiced", "free", "paid")
 
     def _membership_state_prior(self):
         """Inherit this method to define membership state precedence
@@ -167,6 +167,9 @@ class ResPartner(models.Model):
                         line.date_cancel and last_cancel < line.date_cancel
                     ):
                         last_cancel = line.date_cancel
+                    if last_cancel and last_from and last_cancel < last_from:
+                        # Membership was restarted after a cancellation
+                        last_cancel = False
                 partner.membership_start = date_from
                 partner.membership_last_start = last_from
                 partner.membership_stop = last_to

--- a/membership_extension/static/description/index.html
+++ b/membership_extension/static/description/index.html
@@ -459,6 +459,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/yajo"><img alt="yajo" src="https://github.com/yajo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/vertical-association/tree/16.0/membership_extension">OCA/vertical-association</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
When a membership got cancelled and, later, restarted, we still had a cancellation date set, leading to the sensation that it was still cancelled.

With this refactor, when a cancellation date is earlier than a future start date, cancellation info is removed from the partner.

Before:
![image](https://github.com/user-attachments/assets/979dc5ab-959e-472c-ae61-00a6a70901dd)

After:
![image](https://github.com/user-attachments/assets/3d42143e-7fa9-4088-a415-9152be15894c)


BTW I improved a few things:
- Removed old dead code that is no longer necessary in v16.
- Fix a test that was checking what happened when a membership line was cancelled before its start date. It seems a wrong use case because memberships are only supposed to be cancelled during the membership, and not before starting it.
- Free members need to be considered members too.
- Migration script.

@moduon MT-8237