### PR TITLE
[FIX] membership_extension: recover good old behavior of membership last start

### DIFF
--- a/membership_extension/migrations/16.0.3.0.2/post-recompute.py
+++ b/membership_extension/migrations/16.0.3.0.2/post-recompute.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["res.partner"].search(
+        [("membership_last_start", "!=", False)]
+    )._compute_membership_date()

--- a/membership_extension/models/res_partner.py
+++ b/membership_extension/models/res_partner.py
@@ -40,7 +40,7 @@ class ResPartner(models.Model):
         readonly=True,
         store=True,
         compute="_compute_membership_date",
-        help="Date from which membership becomes active.",
+        help="Earliest historical date this partner ever became a member.",
         recursive=True,
     )
     membership_last_start = fields.Date(
@@ -48,7 +48,7 @@ class ResPartner(models.Model):
         readonly=True,
         store=True,
         compute="_compute_membership_date",
-        help="Start date of last membership period.",
+        help="Date when the partner became a member for the last time.",
         recursive=True,
     )
     membership_stop = fields.Date(
@@ -56,7 +56,7 @@ class ResPartner(models.Model):
         readonly=True,
         store=True,
         compute="_compute_membership_date",
-        help="Date until which membership remains active.",
+        help="Date when the latest partner's membership ends.",
         recursive=True,
     )
     membership_cancel = fields.Date(
@@ -158,7 +158,7 @@ class ResPartner(models.Model):
                             continue
                         date_to = line_date_to + timedelta(days=delta)
                         if not last_from or (
-                            last_from <= date_to and last_from < line.date_from
+                            last_from <= date_to and last_from > line.date_from
                         ):
                             last_from = line.date_from
                         if not last_to or last_to < line_date_to:

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -545,7 +545,7 @@ class TestMembership(common.TransactionCase):
             [
                 {
                     "membership_start": date(2022, 1, 1),
-                    "membership_last_start": date(2025, 1, 1),
+                    "membership_last_start": date(2024, 1, 1),
                     "membership_stop": date(2025, 12, 31),
                     "membership_cancel": False,
                     "membership_state": "free",


### PR DESCRIPTION
93c8e75450efc4e08b211e7e4e4a93be438fee28 was supposed to fix https://github.com/OCA/vertical-association/issues/126 but in reality the problem was the misunderstanding of the feature.

Here I'm reverting that commit and changing the help attribute of the fields to be more clear when explaining what each one means. The feature is now tested.

The details are explained in https://github.com/OCA/vertical-association/issues/190#issuecomment-2551150567 (option A).

Fixes https://github.com/OCA/vertical-association/issues/190 
@moduon MT-8237
cc @fcvalgar 