### PR TITLE
[16.0][FIX] membership_delegated_partner + membership_extension + membership_variable_period + membership_prorate: Post-install test + fallback to load CoA

### DIFF
--- a/membership_delegated_partner/tests/test_membership_delegate.py
+++ b/membership_delegated_partner/tests/test_membership_delegate.py
@@ -4,13 +4,23 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.tests import Form, TransactionCase
+from odoo.tests import Form, TransactionCase, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestMembershipDelegate(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.partner1 = cls.env["res.partner"].create({"name": "Mr. Odoo"})
         cls.partner2 = cls.env["res.partner"].create({"name": "Mrs. Odoo"})
         cls.product = cls.env["product.product"].create(

--- a/membership_extension/tests/test_membership.py
+++ b/membership_extension/tests/test_membership.py
@@ -10,16 +10,25 @@ from psycopg2 import IntegrityError
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tools import mute_logger
 
 
-@freeze_time("2025-01-01")
+@tagged("-at_install", "post_install")
 class TestMembership(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        date_today = fields.Date.today()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        date_today = fields.Date.from_string("2025-01-01")
 
         cls.account_bank = cls.env["account.account"].create(
             {
@@ -79,7 +88,7 @@ class TestMembership(common.TransactionCase):
                 "type": "service",
                 "name": "Membership Gold",
                 "membership": True,
-                "membership_date_from": fields.Date.today(),
+                "membership_date_from": date_today,
                 "membership_date_to": cls.next_month,
                 "membership_category_id": cls.category_gold.id,
                 "list_price": 100.00,
@@ -90,7 +99,7 @@ class TestMembership(common.TransactionCase):
                 "type": "service",
                 "name": "Membership Silver",
                 "membership": True,
-                "membership_date_from": fields.Date.today(),
+                "membership_date_from": date_today,
                 "membership_date_to": cls.next_two_months,
                 "membership_category_id": cls.category_silver.id,
                 "list_price": 50.00,
@@ -98,6 +107,7 @@ class TestMembership(common.TransactionCase):
         )
         cls.current_year = date_today.year
 
+    @freeze_time("2025-01-01")
     def test_compute_membership(self):
         line = self.env["membership.membership_line"].create(
             {
@@ -188,6 +198,7 @@ class TestMembership(common.TransactionCase):
         self.partner.free_member = True
         self.assertEqual("free", self.child.membership_state)
 
+    @freeze_time("2025-01-01")
     def test_category(self):
         line_one = self.env["membership.membership_line"].create(
             {
@@ -245,6 +256,7 @@ class TestMembership(common.TransactionCase):
         invoice.invoice_line_ids.with_context(check_move_validity=False).unlink()
         self.assertFalse(self.partner.member_lines)
 
+    @freeze_time("2025-01-01")
     def test_membership_line_onchange(self):
         line = self.env["membership.membership_line"].create(
             {
@@ -265,6 +277,7 @@ class TestMembership(common.TransactionCase):
         self.assertEqual(fields.Date.today(), line.date_from)
         self.assertEqual(self.next_two_months, line.date_to)
 
+    @freeze_time("2025-01-01")
     def test_invoice(self):
         invoice_form = common.Form(
             self.env["account.move"].with_context(default_move_type="out_invoice")
@@ -350,6 +363,7 @@ class TestMembership(common.TransactionCase):
         invoice.action_post()
         self.assertEqual("invoiced", line.state)
 
+    @freeze_time("2025-01-01")
     def test_check_membership_all(self):
         self.env["membership.membership_line"].create(
             {
@@ -399,6 +413,7 @@ class TestMembership(common.TransactionCase):
         partner2.unlink()
         self.assertFalse(partner2.exists())
 
+    @freeze_time("2025-01-01")
     def test_adhered_member(self):
         self.env["membership.membership_line"].create(
             {

--- a/membership_prorate/tests/test_membership_prorate.py
+++ b/membership_prorate/tests/test_membership_prorate.py
@@ -6,7 +6,7 @@ from datetime import date
 from odoo.tests import Form, common
 
 
-class TestMembershipProrate(common.SavepointCase):
+class TestMembershipProrate(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/membership_prorate/tests/test_membership_prorate.py
+++ b/membership_prorate/tests/test_membership_prorate.py
@@ -3,13 +3,23 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from datetime import date
 
-from odoo.tests import Form, common
+from odoo.tests import Form, common, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestMembershipProrate(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Membership product with prorate",

--- a/membership_prorate_variable_period/models/product_template.py
+++ b/membership_prorate_variable_period/models/product_template.py
@@ -4,14 +4,19 @@
 import math
 
 from odoo import _, exceptions, models
-from odoo.tools import date_utils
+from odoo.tools import config, date_utils
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     def _get_next_date(self, date, qty=1):
-        next_date = super(ProductTemplate, self)._get_next_date(date)
+        next_date = super()._get_next_date(date, qty=qty)
+        testing_other_modules = config["test_enable"] and not self.env.context.get(
+            "test_membership_prorate_variable_period"
+        )
+        if testing_other_modules:
+            return next_date
         if self.membership_interval_unit == "days":
             raise exceptions.UserError(_("It's not possible to prorate daily periods."))
         qty = math.ceil(qty) * self.membership_interval_qty

--- a/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
+++ b/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
@@ -4,9 +4,10 @@
 import datetime
 
 from odoo import exceptions, fields
-from odoo.tests import Form, TransactionCase
+from odoo.tests import Form, TransactionCase, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestMembershipProrateVariablePeriod(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -14,6 +15,15 @@ class TestMembershipProrateVariablePeriod(TransactionCase):
         cls.env = cls.env(
             context=dict(cls.env.context, test_membership_prorate_variable_period=True)
         )
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Membership product with prorate",

--- a/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
+++ b/membership_prorate_variable_period/tests/test_membership_prorate_variable_period.py
@@ -11,6 +11,9 @@ class TestMembershipProrateVariablePeriod(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_membership_prorate_variable_period=True)
+        )
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Membership product with prorate",

--- a/membership_variable_period/tests/test_membership_variable_period.py
+++ b/membership_variable_period/tests/test_membership_variable_period.py
@@ -6,13 +6,24 @@
 from datetime import date
 
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestMembershipVariablePeriod(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.product = self.env["product.product"].create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        cls.product = cls.env["product.product"].create(
             {
                 "name": "Membership product with variable period",
                 "membership": True,
@@ -21,7 +32,7 @@ class TestMembershipVariablePeriod(common.TransactionCase):
                 "membership_interval_unit": "weeks",
             }
         )
-        self.partner = self.env["res.partner"].create({"name": "Test"})
+        cls.partner = cls.env["res.partner"].create({"name": "Test"})
 
     def create_invoice(self, invoice_date, quantity=1.0):
         invoice_form = common.Form(


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa