### PR TITLE
[16.0][IMP] membership_delegated_partner: allow multiple delegated members per invoice

### DIFF
--- a/membership_delegated_partner/README.rst
+++ b/membership_delegated_partner/README.rst
@@ -45,8 +45,12 @@ permission on.
 Usage
 =====
 
-#. In an invoice with membership lines, choose a delegated partner.
+#. In an invoice with membership lines, choose a delegated partner directly on
+   the lines or globally on the invoice.
 #. The membership line will go to the delegated partner.
+
+A delegated partner defined on an invoice line has priority over the delegated
+partner defined globally on the invoice.
 
 Bug Tracker
 ===========

--- a/membership_delegated_partner/i18n/fr.po
+++ b/membership_delegated_partner/i18n/fr.po
@@ -2,26 +2,28 @@
 # This file contains the translation of the following modules:
 # * membership_delegated_partner
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-02 01:54+0000\n"
-"PO-Revision-Date: 2022-05-30 18:05+0000\n"
-"Last-Translator: Abdourahmane Wone <abdourahmanewone@gmail.com>\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2025-04-24 19:45+0000\n"
+"PO-Revision-Date: 2025-04-24 19:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
+
+#. module: membership_delegated_partner
+#: model:ir.model.fields,help:membership_delegated_partner.field_account_move_line__membership
+msgid "Check if the product is eligible for membership."
+msgstr "Vérifier si le produit est éligible pour l'adhésion."
 
 #. module: membership_delegated_partner
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_bank_statement_line__delegated_member_id
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move__delegated_member_id
+#: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move_line__delegated_member_id
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_payment__delegated_member_id
 msgid "Delegated Member"
 msgstr "Membre délégué"
@@ -34,12 +36,17 @@ msgstr "Partenaire délégué en adhésion"
 #. module: membership_delegated_partner
 #: model:ir.model,name:membership_delegated_partner.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Entrée de journal"
 
 #. module: membership_delegated_partner
 #: model:ir.model,name:membership_delegated_partner.model_account_move_line
 msgid "Journal Item"
 msgstr "Élément de journal"
+
+#. module: membership_delegated_partner
+#: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move_line__membership
+msgid "Membership"
+msgstr "Adhésion"
 
 #. module: membership_delegated_partner
 #: model:ir.model,name:membership_delegated_partner.model_membership_membership_line
@@ -50,6 +57,3 @@ msgstr "Ligne d'adhésion"
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_membership_membership_line__partner
 msgid "Partner"
 msgstr "Partenaire"
-
-#~ msgid "Journal Entries"
-#~ msgstr "Entrées de journal"

--- a/membership_delegated_partner/i18n/membership_delegated_partner.pot
+++ b/membership_delegated_partner/i18n/membership_delegated_partner.pot
@@ -14,8 +14,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: membership_delegated_partner
+#: model:ir.model.fields,help:membership_delegated_partner.field_account_move_line__membership
+msgid "Check if the product is eligible for membership."
+msgstr ""
+
+#. module: membership_delegated_partner
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_bank_statement_line__delegated_member_id
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move__delegated_member_id
+#: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move_line__delegated_member_id
 #: model:ir.model.fields,field_description:membership_delegated_partner.field_account_payment__delegated_member_id
 msgid "Delegated Member"
 msgstr ""
@@ -33,6 +39,11 @@ msgstr ""
 #. module: membership_delegated_partner
 #: model:ir.model,name:membership_delegated_partner.model_account_move_line
 msgid "Journal Item"
+msgstr ""
+
+#. module: membership_delegated_partner
+#: model:ir.model.fields,field_description:membership_delegated_partner.field_account_move_line__membership
+msgid "Membership"
 msgstr ""
 
 #. module: membership_delegated_partner

--- a/membership_delegated_partner/models/account_move.py
+++ b/membership_delegated_partner/models/account_move.py
@@ -15,9 +15,16 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
+    delegated_member_id = fields.Many2one(comodel_name="res.partner")
+    membership = fields.Boolean(related="product_id.membership", readonly=True)
+
     def _get_partner_for_membership(self):
         """Auxiliary method for getting the correct membership partner for
         certain operations like initial fee check.
         """
         self.ensure_one()
-        return self.move_id.delegated_member_id or self.move_id.partner_id
+        return (
+            self.delegated_member_id
+            or self.move_id.delegated_member_id
+            or self.move_id.partner_id
+        )

--- a/membership_delegated_partner/models/membership_line.py
+++ b/membership_delegated_partner/models/membership_line.py
@@ -11,6 +11,7 @@ class MembershipLine(models.Model):
     partner = fields.Many2one(compute="_compute_partner", store=True, readonly=False)
 
     @api.depends(
+        "account_invoice_line.delegated_member_id",
         "account_invoice_line.move_id.delegated_member_id",
         "account_invoice_line.move_id.partner_id",
     )
@@ -28,8 +29,7 @@ class MembershipLine(models.Model):
             if "account_invoice_line" not in vals:
                 continue
             line = self.env["account.move.line"].browse(vals["account_invoice_line"])
-            if line.move_id.delegated_member_id:
-                vals["partner"] = line.move_id.delegated_member_id.id
+            vals["partner"] = line._get_partner_for_membership().id
         return super().create(vals_list)
 
     def write(self, vals):
@@ -42,6 +42,6 @@ class MembershipLine(models.Model):
             )
         else:
             inv_line = self.account_invoice_line
-        if inv_line and inv_line.move_id.delegated_member_id:
-            vals["partner"] = inv_line.move_id.delegated_member_id.id
+        if inv_line:
+            vals["partner"] = inv_line._get_partner_for_membership().id
         return super().write(vals)

--- a/membership_delegated_partner/readme/USAGE.rst
+++ b/membership_delegated_partner/readme/USAGE.rst
@@ -1,2 +1,6 @@
-#. In an invoice with membership lines, choose a delegated partner.
+#. In an invoice with membership lines, choose a delegated partner directly on
+   the lines or globally on the invoice.
 #. The membership line will go to the delegated partner.
+
+A delegated partner defined on an invoice line has priority over the delegated
+partner defined globally on the invoice.

--- a/membership_delegated_partner/static/description/index.html
+++ b/membership_delegated_partner/static/description/index.html
@@ -394,9 +394,12 @@ permission on.</p>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <ol class="arabic simple">
-<li>In an invoice with membership lines, choose a delegated partner.</li>
+<li>In an invoice with membership lines, choose a delegated partner directly on
+the lines or globally on the invoice.</li>
 <li>The membership line will go to the delegated partner.</li>
 </ol>
+<p>A delegated partner defined on an invoice line has priority over the delegated
+partner defined globally on the invoice.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>

--- a/membership_delegated_partner/views/account_move.xml
+++ b/membership_delegated_partner/views/account_move.xml
@@ -12,6 +12,17 @@
                     groups="membership_delegated_partner.group_delegated_member"
                 />
             </field>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/tree/field[@name='quantity']"
+                position="before"
+            >
+                <field name="membership" invisible="1" />
+                <field
+                    name="delegated_member_id"
+                    attrs="{'readonly':[('membership', '=', False)], 'column_invisible':[('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    groups="membership_delegated_partner.group_delegated_member"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
It is now possible to define a delegate member per invoice line (in addition to the one defined on the invoice). A customer can therefore be invoiced for the memberships of several partners.

A delegated member defined on an invoice line has priority over the delegated member defined globally on the invoice.