### PR TITLE
[16.0][IMP] membership_extension: remove Member Free membership when Invoice is created

### DIFF
--- a/membership_extension/models/account_move_line.py
+++ b/membership_extension/models/account_move_line.py
@@ -3,7 +3,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-
+import logging
+_logger = logging.getLogger(__name__)
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -18,6 +19,10 @@ class AccountMoveLine(models.Model):
         for line in lines:
             if line.move_id.move_type == "out_invoice" and line.product_id.membership:
                 line.membership_lines.write({"state": "waiting"})
+                #line.membership_lines.mapped("partner").write({"free_member": False})
+                for partner in line.membership_lines.mapped("partner"):
+                    _logger.info("Atualizando parceiro: %s", partner.id)
+                    partner.write({"free_member": False})
         return lines
 
     def unlink(self):

--- a/membership_extension/models/account_move_line.py
+++ b/membership_extension/models/account_move_line.py
@@ -3,8 +3,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-import logging
-_logger = logging.getLogger(__name__)
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -21,7 +19,6 @@ class AccountMoveLine(models.Model):
                 line.membership_lines.write({"state": "waiting"})
                 #line.membership_lines.mapped("partner").write({"free_member": False})
                 for partner in line.membership_lines.mapped("partner"):
-                    _logger.info("Atualizando parceiro: %s", partner.id)
                     partner.write({"free_member": False})
         return lines
 

--- a/membership_extension/models/account_move_line.py
+++ b/membership_extension/models/account_move_line.py
@@ -4,6 +4,7 @@
 
 from odoo import api, fields, models
 
+
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 

--- a/membership_extension/models/account_move_line.py
+++ b/membership_extension/models/account_move_line.py
@@ -17,7 +17,6 @@ class AccountMoveLine(models.Model):
         for line in lines:
             if line.move_id.move_type == "out_invoice" and line.product_id.membership:
                 line.membership_lines.write({"state": "waiting"})
-                #line.membership_lines.mapped("partner").write({"free_member": False})
                 for partner in line.membership_lines.mapped("partner"):
                     partner.write({"free_member": False})
         return lines

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -101,13 +101,10 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="membership.view_res_partner_member_filter" />
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='all_members']" position="replace">
-                <filter
-                    name="all_members"
-                    string="Members"
-                    domain="[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]"
-                    help="Invoiced/Paid/Free/Waiting"
-                />
+            <xpath expr="//filter[@name='all_members']" position="attributes">
+                <attribute name="domain">[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]</attribute>
+                <attribute name="help">Invoiced/Paid/Free/Waiting</attribute>
+                <attribute name="string">Members</attribute>
             </xpath>
             <xpath expr="//group" position="inside">
                 <filter

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -102,7 +102,6 @@
         <field name="inherit_id" ref="membership.view_res_partner_member_filter" />
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='all_members']" position="attributes">
-                <attribute name="domain">[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]</attribute>
                 <attribute
                     name="domain"
                 >[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]</attribute>

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -103,6 +103,9 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='all_members']" position="attributes">
                 <attribute name="domain">[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]</attribute>
+                <attribute
+                    name="domain"
+                >[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]</attribute>
                 <attribute name="help">Invoiced/Paid/Free/Waiting</attribute>
                 <attribute name="string">Members</attribute>
             </xpath>

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -123,5 +123,4 @@
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/membership_extension/views/res_partner_view.xml
+++ b/membership_extension/views/res_partner_view.xml
@@ -101,6 +101,14 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="membership.view_res_partner_member_filter" />
         <field name="arch" type="xml">
+            <xpath expr="//filter[@name='all_members']" position="replace">
+                <filter
+                    name="all_members"
+                    string="Members"
+                    domain="[('membership_state', 'in', ['invoiced', 'paid', 'free', 'waiting'])]"
+                    help="Invoiced/Paid/Free/Waiting"
+                />
+            </xpath>
             <xpath expr="//group" position="inside">
                 <filter
                     string="Last Start Month"
@@ -118,4 +126,5 @@
             </xpath>
         </field>
     </record>
+
 </odoo>


### PR DESCRIPTION
Fixes #208

**Describe the solution you'd like**
When an Member is created, it is marked as a Free Member. But, when an Invoice is created, the **Membership Line status is change to 'waiting'**, 'invoiced' and after 'paid', **but the Member is still marked as an Free Member**.

**Describe alternatives you've considered**
When an Invoice is created for a Membership product, and the status of the Membership Line is changed to 'waiting', **set the Member free_member = False**.
This feature make sense to me because, when we create a Invoice to the Member he is not a Free Member anymore and we need to track his invoice/payment for now on.

With this in mind, we need to extend the Partner Membership view as well, to consider Members on kanban list with state 'waiting' too.